### PR TITLE
Remove variable declaration from for-loop header and enclose in block

### DIFF
--- a/oursqlx/_exceptions.c
+++ b/oursqlx/_exceptions.c
@@ -618,7 +618,9 @@ enum _oursqlx_exception_type _oursqlx_exc_from_errno(int err) {
 
         default:
             #if MYSQL_VERSION_ID >= 50700
-                for(unsigned int i = 0; i < sizeof(errmsg_section_start)/sizeof(int); ++i) {
+            {
+                unsigned int i;
+                for(i = 0; i < sizeof(errmsg_section_start)/sizeof(int); ++i) {
                     int min = errmsg_section_start[i];
                     int max = errmsg_section_start[i] + errmsg_section_size[i] - 1;
                     if ( err >= min && err <= max ) {
@@ -628,6 +630,7 @@ enum _oursqlx_exception_type _oursqlx_exc_from_errno(int err) {
                 if ( err > CR_MIN_ERROR && err < CR_MAX_ERROR) {
                     return _oursqlx_InterfaceError;
                 }
+            }
             #else
                 if (err >= ER_ERROR_FIRST && err <= ER_ERROR_LAST)
                     return _oursqlx_ProgrammingError;

--- a/oursqlx/_exceptions.c
+++ b/oursqlx/_exceptions.c
@@ -617,23 +617,23 @@ enum _oursqlx_exception_type _oursqlx_exc_from_errno(int err) {
             return _oursqlx_PermissionsError;
 
         default:
-           #if MYSQL_VERSION_ID >= 50700 
-              for(unsigned int i = 0; i < sizeof(errmsg_section_start)/sizeof(int); ++i) {
-                int min = errmsg_section_start[i];
-                int max = errmsg_section_start[i] + errmsg_section_size[i] - 1;
-                if ( err >= min && err <= max ) {
-                  return _oursqlx_ProgrammingError;
-                }             
-              }
-              if ( err > CR_MIN_ERROR && err < CR_MAX_ERROR) {
-                 return _oursqlx_InterfaceError;
-              }
-           #else
-              if (err >= ER_ERROR_FIRST && err <= ER_ERROR_LAST)
-                  return _oursqlx_ProgrammingError;
-              else if (err > CR_MIN_ERROR && err < CR_MAX_ERROR)
-                  return _oursqlx_InterfaceError;
-           #endif
+            #if MYSQL_VERSION_ID >= 50700
+                for(unsigned int i = 0; i < sizeof(errmsg_section_start)/sizeof(int); ++i) {
+                    int min = errmsg_section_start[i];
+                    int max = errmsg_section_start[i] + errmsg_section_size[i] - 1;
+                    if ( err >= min && err <= max ) {
+                      return _oursqlx_ProgrammingError;
+                    }
+                }
+                if ( err > CR_MIN_ERROR && err < CR_MAX_ERROR) {
+                    return _oursqlx_InterfaceError;
+                }
+            #else
+                if (err >= ER_ERROR_FIRST && err <= ER_ERROR_LAST)
+                    return _oursqlx_ProgrammingError;
+                else if (err > CR_MIN_ERROR && err < CR_MAX_ERROR)
+                    return _oursqlx_InterfaceError;
+            #endif
     }
     return _oursqlx_UnknownError;
 }


### PR DESCRIPTION
This solves `error: for loop initial declarations are only allowed in C99 mode` when building on gcc 4.4.7 (Default gcc on CentOS 6.x) against the MySQL 5.7 libs.

This PR has two commits, the first commit only alters indentation because this appears to have accidentally been indented with 3 spaces instead of 4, so it was messing with my editor.

The important portion of the diff is in the second commit: https://github.com/python-oursql/oursql/commit/9ffee5dc887bd1a22cb55a708699007ac58437f7

See also: https://github.com/python-oursql/oursql/pull/4 which introduced 5.7 support.
