### PR TITLE
make oursql compile against mariadb and mysql 5.6 / 5.7

### DIFF
--- a/oursqlx/_exceptions.c
+++ b/oursqlx/_exceptions.c
@@ -617,8 +617,10 @@ enum _oursqlx_exception_type _oursqlx_exc_from_errno(int err) {
             return _oursqlx_PermissionsError;
 
         default:
-           #if MYSQL_VERSION_ID >= 50700 
-              for(unsigned int i = 0; i < sizeof(errmsg_section_start)/sizeof(int); ++i) {
+           #if MYSQL_VERSION_ID >= 50700 && !defined(ER_ERROR_FIRST)
+           {
+              unsigned int i;
+              for(i = 0; i < sizeof(errmsg_section_start)/sizeof(int); ++i) {
                 int min = errmsg_section_start[i];
                 int max = errmsg_section_start[i] + errmsg_section_size[i] - 1;
                 if ( err >= min && err <= max ) {
@@ -628,6 +630,7 @@ enum _oursqlx_exception_type _oursqlx_exc_from_errno(int err) {
               if ( err > CR_MIN_ERROR && err < CR_MAX_ERROR) {
                  return _oursqlx_InterfaceError;
               }
+           }
            #else
               if (err >= ER_ERROR_FIRST && err <= ER_ERROR_LAST)
                   return _oursqlx_ProgrammingError;


### PR DESCRIPTION
This PR should fix https://github.com/python-oursql/oursql/issues/5.

During my tests I also ran into a compilation issue regarding the C version (C99 vs. older), hence I moved the unsigned int declaration out of the loop and created a block for it.

Cheers!