### PR TITLE
check for MARIADB_BASE_VERSION in _exceptions.c

### DIFF
--- a/oursqlx/_exceptions.c
+++ b/oursqlx/_exceptions.c
@@ -617,7 +617,7 @@ enum _oursqlx_exception_type _oursqlx_exc_from_errno(int err) {
             return _oursqlx_PermissionsError;
 
         default:
-           #if MYSQL_VERSION_ID >= 50700 
+           #if MYSQL_VERSION_ID >= 50700 && !defined(MARIADB_BASE_VERSION)
               for(unsigned int i = 0; i < sizeof(errmsg_section_start)/sizeof(int); ++i) {
                 int min = errmsg_section_start[i];
                 int max = errmsg_section_start[i] + errmsg_section_size[i] - 1;


### PR DESCRIPTION
Debian Stretch appears to ship with MariaDB rather than MySQL.

MariaDB's `mysqld_error.h` does not define `errmsg_section_start`, which causes `pip install oursql` to fail:

```
# pip install oursql
Collecting oursql
  Using cached https://files.pythonhosted.org/packages/8c/88/9f53a314a2af6f56c0a1249c5673ee384b85dc791bac5c1228772ced3502/oursql-0.9.3.2.tar.gz
Building wheels for collected packages: oursql
  Running setup.py bdist_wheel for oursql ... error
  Complete output from command /usr/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-SIHaOA/oursql/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmpc5pcILpip-wheel- --python-tag cp27:
  cython not found, using previously-cython'd .c file.
  running bdist_wheel
  running build
  running build_ext
  building 'oursql' extension
  mysql_config --cflags
  creating build
  creating build/temp.linux-x86_64-2.7
  creating build/temp.linux-x86_64-2.7/oursqlx
  x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fno-strict-aliasing -Wdate-time -D_FORTIFY_SOURCE=2 -g -fdebug-prefix-map=/build/python2.7-2.7.13=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -I/usr/include/python2.7 -c oursqlx/oursql.c -o build/temp.linux-x86_64-2.7/oursqlx/oursql.o -I/usr/include/mysql
  x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fno-strict-aliasing -Wdate-time -D_FORTIFY_SOURCE=2 -g -fdebug-prefix-map=/build/python2.7-2.7.13=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -I/usr/include/python2.7 -c oursqlx/compat.c -o build/temp.linux-x86_64-2.7/oursqlx/compat.o -I/usr/include/mysql
  In file included from oursqlx/compat.c:55:0:
  oursqlx/_exceptions.c: In function '_oursqlx_exc_from_errno':
  oursqlx/_exceptions.c:621:50: error: 'errmsg_section_start' undeclared (first use in this function)
                 for(unsigned int i = 0; i < sizeof(errmsg_section_start)/sizeof(int); ++i) {
                                                    ^~~~~~~~~~~~~~~~~~~~
  oursqlx/_exceptions.c:621:50: note: each undeclared identifier is reported only once for each function it appears in
  oursqlx/_exceptions.c:623:53: error: 'errmsg_section_size' undeclared (first use in this function)
                   int max = errmsg_section_start[i] + errmsg_section_size[i] - 1;
                                                       ^~~~~~~~~~~~~~~~~~~
  error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
```

However, oursql has an alternative code path which does not use `errmsg_section_size`, which I think can be used for Maria DB.

The problem is that Maria DB defines `MYSQL_VERSION_ID`, which causes the `#if MYSQL_VERSION_ID >= 50700` code branch to get used.

I think we can simply extend that predicate with `&& !defined(MARIADB_BASE_VERSION)`, which will cause Maria DB to use the alternative code path.

Note that I haven't tested this, as I'm not sure how to make a pip module rebuild with my local changes.